### PR TITLE
添加Docker运行方式

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-alpine
+
+WORKDIR /app
+ADD . /app
+
+RUN pip install -r requirements.txt
+RUN apk update && apk add python3-tkinter
+
+CMD ["python3", "-u", "main.py", "start"]

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ https://baimianxiao.github.io/AcgDraw/
 ```shell
 python3 main.py init # Windows请使用python main.py init
 ```
-2.使用仓库中的Dockerfile构建镜像
+2.将conf/global.json中的`"host":"127.0.0.1"`改为`"host":"0.0.0.0"`，因为Docker中的127.0.0.1默认不会监听容器外的地址
+
+3.使用仓库中的Dockerfile构建镜像
 ```shell
 docker build -t acgdraw .
 ```
-3.运行容器(端口可根据您设置的config文件自行调整)
+4.运行容器(端口可根据您设置的config文件自行调整)
 ```shell
 docker run -d -p 11451:11451 --name=acgdraw acgdraw
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@
 
 https://baimianxiao.github.io/AcgDraw/
 
+## Docker运行
+1.在编译镜像之前请手动运行一次init以下载素材。如果data中已经下载好素材了(即已经手动运行成功过)则可以跳过这一步 \
+请注意运行init也需要先在本机安装requirements.txt中的依赖
+```shell
+python3 main.py init # Windows请使用python main.py init
+```
+2.使用仓库中的Dockerfile构建镜像
+```shell
+docker build -t acgdraw .
+```
+3.运行容器(端口可根据您设置的config文件自行调整)
+```shell
+docker run -d -p 11451:11451 --name=acgdraw acgdraw
+```
+
 ## 协议
 GPL-3.0 license
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 
 """
 import os
+import sys
 from os.path import abspath, dirname, join
 from json import dumps, loads
 import AcgDraw
@@ -53,24 +54,46 @@ create_dir_list = [
 ]
 
 print("Arknights-Draw")
-input("按任意键继续")
-if not os.path.exists("./data/lock.lock"):
-    print("服务器未部署，开始部署")
-    for create_dir in create_dir_list:
-        mkdir(create_dir)
-    try:
-        AcgDraw.updateArk.UpdateHandleArk("./data/Arknights/", "./conf/Arknights/").start_update()
-        with open("./data/lock.lock", 'w', encoding='utf-8') as f:
-            f.write("")
-        AcgDraw.server.server_start(host=host, port=port)
-    except:
-        print("部署发生错误，请重试")
-        input("按任意键继续")
-else:
-    print("服务器已部署\n1.启动服务器\n2.启动更新")
-    x = input("请选择操作:")
-    if int(x) == 1:
-        AcgDraw.server.server_start(host=host, port=port)
-    elif int(x) == 2:
+if len(sys.argv) > 1: # 自动运行
+    if sys.argv[1] == "init":
+        print("服务器未部署，开始部署")
+        for create_dir in create_dir_list:
+            mkdir(create_dir)
+        try:
+            AcgDraw.updateArk.UpdateHandleArk("./data/Arknights/", "./conf/Arknights/").start_update()
+            with open("./data/lock.lock", 'w', encoding='utf-8') as f:
+                f.write("")
+        except:
+            print("部署发生错误，请重试")
+            exit(1)
+        exit(0)
+    elif sys.argv[1] == "update":
         AcgDraw.updateArk.UpdateHandleArk("./data/Arknights/", "./conf/Arknights/").start_update()
         AcgDraw.server.server_start(host=host, port=port)
+    elif sys.argv[1] == "start":
+        AcgDraw.server.server_start(host=host, port=port)
+    else:
+        print("参数错误")
+        exit(1)
+else: # 交互式
+    input("按任意键继续")
+    if not os.path.exists("./data/lock.lock"):
+        print("服务器未部署，开始部署")
+        for create_dir in create_dir_list:
+            mkdir(create_dir)
+        try:
+            AcgDraw.updateArk.UpdateHandleArk("./data/Arknights/", "./conf/Arknights/").start_update()
+            with open("./data/lock.lock", 'w', encoding='utf-8') as f:
+                f.write("")
+            AcgDraw.server.server_start(host=host, port=port)
+        except:
+            print("部署发生错误，请重试")
+            input("按任意键继续")
+    else:
+        print("服务器已部署\n1.启动服务器\n2.启动更新")
+        x = input("请选择操作:")
+        if int(x) == 1:
+            AcgDraw.server.server_start(host=host, port=port)
+        elif int(x) == 2:
+            AcgDraw.updateArk.UpdateHandleArk("./data/Arknights/", "./conf/Arknights/").start_update()
+            AcgDraw.server.server_start(host=host, port=port)


### PR DESCRIPTION
因为部分服务器Python版本较老，甚至无法安装Pillow10+...故在此提供一个Docker运行的方法
我看Doc还没开始写，故暂时在README部分添加了Docker运行方法的教程。
因为Docker容器的一次性运行性质，目前是要求先在本地将Data获取完后再构建镜像（其实更主要的原因是海外服务器运行update的速度非常之慢，我是自行update后再手动将data文件夹替换上去的）。
之后可以考虑通过持久化储存（即将本地data目录映射到容器内）
或
直接提供下载好data的在线镜像拉取运行，比如我自己目前在用的：
```bash
docker run -d --name=acgdraw -p 11451:11451 sahuidhsu/acg_draw
```